### PR TITLE
Rename config file to dirt.cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+__pycache__/
+.pytest_cache/
+*.pyc
+*.log
+index.php
+debug.php

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ DiRT consists of two main components:
 
 3.  **Configure the plugin**:
     *   Copy the plugin files to the appropriate directories on your UnRAID server.
-    *   The main configuration file is located at `/boot/config/plugins/bobbintb.system.dirt/bobbintb.system.dirt.cfg`. You can edit this file to specify the shares to monitor and other settings.
+    *   The main configuration file is located at `/boot/config/plugins/bobbintb.system.dirt/dirt.cfg`. You can edit this file to specify the shares to monitor and other settings.
 
 ### Running the Application
 

--- a/dirt-main.page
+++ b/dirt-main.page
@@ -5,7 +5,8 @@ Title="Main"
 //require_once "$docroot/plugins/dynamix.vm.manager/include/libvirt_helpers.php";
 //require_once "$docroot/plugins/dynamix/include/Helpers.php";
 $plugin  = 'bobbintb.system.dirt';
-$cfg     = parse_plugin_cfg($plugin);
+$cfg_file = "/boot/config/plugins/$plugin/dirt.cfg";
+$cfg     = is_file($cfg_file) ? parse_ini_file($cfg_file) : [];
 $width   = [400,300];
 $blacklist = ['system'];
 $cfg['datetime_format']	= $cfg['datetime_format'] ?? "f";
@@ -16,7 +17,7 @@ $cfg['share'] = $cfg['share'] ?? implode(',', array_diff(array_column($shares, '
 
 
 <form markdown="1" name="dirt_settings" method="POST" action="/update.php" target="progressFrame" onsubmit="prepareShare(this)">
-<input type="hidden" name="#file" value="<?= htmlspecialchars($plugin . '/' . $plugin . '.cfg') ?>">
+<input type="hidden" name="#file" value="<?= htmlspecialchars($plugin . '/dirt.cfg') ?>">
 
 _(Included share(s))_:
 : <select id="share" name="share" multiple style="display:none">

--- a/nodejs/config-helper.js
+++ b/nodejs/config-helper.js
@@ -4,7 +4,7 @@ const path = require('path');
 async function getPluginConfig() {
   const plugin = 'bobbintb.system.dirt';
   const baseDir = process.env.DIRT_CONFIG_DIR || '/boot/config';
-  const cfgPath = `${baseDir}/plugins/${plugin}/${plugin}.cfg`;
+  const cfgPath = `${baseDir}/plugins/${plugin}/dirt.cfg`;
   const config = {
     datetime_format: 'f', // Default
   };


### PR DESCRIPTION
This change renames the plugin's configuration file from the plugin-named `bobbintb.system.dirt.cfg` to just `dirt.cfg`. This involves updates to the Node.js backend, the PHP frontend, and the project documentation. A `.gitignore` file was also added to keep the repository clean of test and dependency artifacts.

---
*PR created automatically by Jules for task [8043909469192539020](https://jules.google.com/task/8043909469192539020) started by @bobbintb*