### PR TITLE
Restore service control functionality on debug page

### DIFF
--- a/dirt-debug.page
+++ b/dirt-debug.page
@@ -315,6 +315,9 @@ $(function() {
                 badge.text(isRunning ? 'RUNNING' : 'STOPPED')
                      .removeClass('status-enabled status-disabled')
                      .addClass(isRunning ? 'status-enabled' : 'status-disabled');
+
+                $(`#${service}-start-btn`).prop('disabled', isRunning);
+                $(`#${service}-stop-btn`).prop('disabled', !isRunning);
             });
         });
     }

--- a/dirt-debug.page
+++ b/dirt-debug.page
@@ -307,10 +307,44 @@ $(function() {
         }
     }
 
+    function refreshServiceStatus() {
+        $.get('/plugins/bobbintb.system.dirt/service_manager.php?get_service_status=1', function(data) {
+            ['valkey', 'nodejs', 'dirt'].forEach(function(service) {
+                const isRunning = data[service];
+                const badge = $(`#${service}-status-badge`);
+                badge.text(isRunning ? 'RUNNING' : 'STOPPED')
+                     .removeClass('status-enabled status-disabled')
+                     .addClass(isRunning ? 'status-enabled' : 'status-disabled');
+            });
+        });
+    }
+
     connect();
+    refreshServiceStatus();
 
 
     // --- Event Listeners ---
+    ['valkey', 'nodejs', 'dirt'].forEach(function(service) {
+        $(`#${service}-start-btn`).on('click', function() {
+            $.post('/plugins/bobbintb.system.dirt/service_manager.php', {
+                service_action: 1,
+                service: service,
+                action: 'start'
+            }, function() {
+                refreshServiceStatus();
+            });
+        });
+        $(`#${service}-stop-btn`).on('click', function() {
+            $.post('/plugins/bobbintb.system.dirt/service_manager.php', {
+                service_action: 1,
+                service: service,
+                action: 'stop'
+            }, function() {
+                refreshServiceStatus();
+            });
+        });
+    });
+
     $('#by-size-btn').on('click', function() {
         const size = $('#size-input').val();
         if (size) dirtySock('debugFindFilesBySize', parseInt(size, 10));


### PR DESCRIPTION
The service control section on the debug page was broken. I restored the functionality by adding the necessary JavaScript logic to `dirt-debug.page`. The UI now correctly displays service statuses (RUNNING/STOPPED) on page load and updates them immediately after a user clicks a Start or Stop button. The implementation relies on the existing global jQuery provided by Unraid and avoids unnecessary background polling.

---
*PR created automatically by Jules for task [2811606162167470893](https://jules.google.com/task/2811606162167470893) started by @bobbintb*